### PR TITLE
Add post fix strings to parser

### DIFF
--- a/.github/workflows/clang-format.yml
+++ b/.github/workflows/clang-format.yml
@@ -4,11 +4,12 @@ on: [push]
 
 jobs:
   clang-format-job:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - name: Install clang-format 10.0
+      - name: Install clang-format 15.0
         run: |
-          sudo apt install clang-format
+          sudo apt-get update
+          sudo apt install clang-format-15
           clang-format --version
       - uses: actions/checkout@v3
       - name: Check format

--- a/src/AsciiTokenizer.cpp
+++ b/src/AsciiTokenizer.cpp
@@ -135,9 +135,8 @@ std::optional<Token> AsciiTokenizer::tokenizeNumber( std::istream& stream )
 {
     tokenizeDelimiter( stream );
 
-    auto isCharValidInDigit = []( char c ) {
-        return std::isdigit( c ) || c == '.' || c == 'e' || c == 'E' || c == '-' || c == '+';
-    };
+    auto isCharValidInDigit = []( char c )
+    { return std::isdigit( c ) || c == '.' || c == 'e' || c == 'E' || c == '-' || c == '+'; };
 
     auto start = stream.tellg();
     auto end   = start;

--- a/src/BinaryTokenizer.cpp
+++ b/src/BinaryTokenizer.cpp
@@ -194,7 +194,8 @@ std::vector<Token> BinaryTokenizer::tokenizeArrayTagKey( std::istream& stream )
     }
     tokens.push_back( numElementsToken.value() );
 
-    auto parseInt = []( const Token& token, std::istream& stream ) {
+    auto parseInt = []( const Token& token, std::istream& stream )
+    {
         int length = Token::binaryTokenSizeInBytes( Token::Kind::INT );
 
         auto start = token.start();

--- a/src/Parser.cpp
+++ b/src/Parser.cpp
@@ -92,18 +92,18 @@ void Parser::parse( std::istream&                                     stream,
             // Special handling for parameter tags.
             // Take the name of parameter as name of the group to avoid
             // name-clashes (multiple properties named parameter.data/codeNames/codeValues).
-            if ( name == "parameter.data" )
+            if ( name == ( "parameter" + postFixData() ) )
             {
                 name     = lastName;
                 lastName = "";
             }
-            else if ( name == "parameter.codeNames" )
+            else if ( name == ( "parameter" + postFixCodeNames() ) )
             {
-                name = lastName + ".codeNames";
+                name = lastName + postFixCodeNames();
             }
-            else if ( name == "parameter.codeValues" )
+            else if ( name == ( "parameter" + postFixCodeValues() ) )
             {
-                name = lastName + ".codeValues";
+                name = lastName + postFixCodeValues();
             }
 
             // Extract number of array items
@@ -158,7 +158,8 @@ std::pair<std::string, RoffScalar> Parser::parseSimpleType( std::vector<Token>::
 
     std::advance( it, 1 );
 
-    auto extractValue = [this]( auto it, Token::Kind kind, std::istream& stream ) {
+    auto extractValue = [this]( auto it, Token::Kind kind, std::istream& stream )
+    {
         if ( kind == Token::Kind::INT ) return RoffScalar( parseInt( *it, stream ) );
         if ( kind == Token::Kind::BOOL ) return RoffScalar( parseBool( *it, stream ) );
         if ( kind == Token::Kind::BYTE ) return RoffScalar( parseByte( *it, stream ) );

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -77,8 +77,8 @@ public:
 
     static bool isSimpleType( Token::Kind kind );
 
-    static constexpr std::string postFixData() { return ".data"; }
-    static constexpr std::string postFixCodeNames() { return ".codeNames"; }
-    static constexpr std::string postFixCodeValues() { return ".codeValues"; }
+    static std::string postFixData() { return ".data"; }
+    static std::string postFixCodeNames() { return ".codeNames"; }
+    static std::string postFixCodeValues() { return ".codeValues"; }
 };
 } // namespace roff

--- a/src/Parser.hpp
+++ b/src/Parser.hpp
@@ -76,5 +76,9 @@ public:
     virtual unsigned char parseByte( const Token& token, std::istream& stream ) const   = 0;
 
     static bool isSimpleType( Token::Kind kind );
+
+    static constexpr std::string postFixData() { return ".data"; }
+    static constexpr std::string postFixCodeNames() { return ".codeNames"; }
+    static constexpr std::string postFixCodeValues() { return ".codeValues"; }
 };
 } // namespace roff

--- a/tests/AsciiTokenizerTests.cpp
+++ b/tests/AsciiTokenizerTests.cpp
@@ -319,7 +319,8 @@ TEST( AsciiTokenizerTests, testTokenizeExampleFile )
     std::vector<Token> tokens = tokenizer.tokenizeStream( stream );
     ASSERT_EQ( 109u, tokens.size() );
 
-    auto readValueForToken = []( std::istream& stream, const Token& token ) {
+    auto readValueForToken = []( std::istream& stream, const Token& token )
+    {
         stream.seekg( token.start() );
         size_t      length = token.end() - token.start();
         std::string res;

--- a/tests/BinaryTokenizerTests.cpp
+++ b/tests/BinaryTokenizerTests.cpp
@@ -281,7 +281,8 @@ TEST( BinaryTokenizerTests, testTokenizeExampleFile )
     BinaryTokenizer    tokenizer;
     std::vector<Token> tokens = tokenizer.tokenizeStream( stream );
 
-    auto readValueForToken = []( std::istream& stream, const Token& token ) {
+    auto readValueForToken = []( std::istream& stream, const Token& token )
+    {
         stream.seekg( token.start() );
         size_t      length = token.end() - token.start();
         std::string res;

--- a/tests/ReaderTests.cpp
+++ b/tests/ReaderTests.cpp
@@ -45,13 +45,15 @@ TEST( ReaderTests, testParseScalarNamedValuesFromExampleFile )
     std::vector<std::pair<std::string, RoffScalar>> values = reader.scalarNamedValues();
     ASSERT_FALSE( values.empty() );
 
-    auto hasValue = []( auto values, const std::string& keyword ) {
-        return std::any_of( values.cbegin(), values.cend(), [&keyword]( const auto& arg ) {
-            return arg.first == keyword;
-        } );
+    auto hasValue = []( auto values, const std::string& keyword )
+    {
+        return std::any_of( values.cbegin(),
+                            values.cend(),
+                            [&keyword]( const auto& arg ) { return arg.first == keyword; } );
     };
 
-    auto getValue = []( const std::vector<std::pair<std::string, RoffScalar>>& values, const std::string& keyword ) {
+    auto getValue = []( const std::vector<std::pair<std::string, RoffScalar>>& values, const std::string& keyword )
+    {
         auto a =
             std::find_if( values.begin(), values.end(), [&keyword]( const auto& arg ) { return arg.first == keyword; } );
         if ( a != values.end() )
@@ -99,24 +101,25 @@ TEST( ReaderTests, testParseArrayValuesFromExampleFile )
     std::vector<std::pair<std::string, Token::Kind>> arrayTypes = reader.getNamedArrayTypes();
     ASSERT_FALSE( arrayTypes.empty() );
 
-    auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind ) {
+    auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind )
+    {
         auto x =
             std::find_if( values.begin(), values.end(), [&keyword]( const auto& arg ) { return arg.first == keyword; } );
         return x != values.end() && x->second == kind;
     };
 
-    ASSERT_TRUE( hasValue( arrayTypes, "composite.codeNames", Token::Kind::CHAR ) );
-    ASSERT_TRUE( hasValue( arrayTypes, "composite.codeValues", Token::Kind::INT ) );
+    ASSERT_TRUE( hasValue( arrayTypes, "composite" + roff::Parser::postFixCodeNames(), Token::Kind::CHAR ) );
+    ASSERT_TRUE( hasValue( arrayTypes, "composite" + roff::Parser::postFixCodeValues(), Token::Kind::INT ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.floatData", Token::Kind::FLOAT ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.doubleData", Token::Kind::DOUBLE ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.intData", Token::Kind::INT ) );
 
-    std::vector<std::string> codeNames = reader.getStringArray( "composite.codeNames" );
+    std::vector<std::string> codeNames = reader.getStringArray( "composite" + roff::Parser::postFixCodeNames() );
     ASSERT_EQ( 6u, codeNames.size() );
     ASSERT_EQ( "code name 1", codeNames[0] );
     ASSERT_EQ( "code name 6", codeNames[5] );
 
-    std::vector<int> codeValues = reader.getIntArray( "composite.codeValues" );
+    std::vector<int> codeValues = reader.getIntArray( "composite" + roff::Parser::postFixCodeValues() );
     ASSERT_EQ( 6u, codeValues.size() );
     for ( int i = 0; i < 6; i++ )
     {
@@ -144,13 +147,15 @@ TEST( ReaderTests, testParseScalarNamedValuesFromBinaryExampleFile )
     std::vector<std::pair<std::string, RoffScalar>> values = reader.scalarNamedValues();
     ASSERT_FALSE( values.empty() );
 
-    auto hasValue = []( auto values, const std::string& keyword ) {
-        return std::any_of( values.cbegin(), values.cend(), [&keyword]( const auto& arg ) {
-            return arg.first == keyword;
-        } );
+    auto hasValue = []( auto values, const std::string& keyword )
+    {
+        return std::any_of( values.cbegin(),
+                            values.cend(),
+                            [&keyword]( const auto& arg ) { return arg.first == keyword; } );
     };
 
-    auto getValue = []( const std::vector<std::pair<std::string, RoffScalar>>& values, const std::string& keyword ) {
+    auto getValue = []( const std::vector<std::pair<std::string, RoffScalar>>& values, const std::string& keyword )
+    {
         auto a =
             std::find_if( values.begin(), values.end(), [&keyword]( const auto& arg ) { return arg.first == keyword; } );
         if ( a != values.end() )
@@ -198,18 +203,19 @@ TEST( ReaderTests, testParseArrayValuesFromBinaryExampleFile )
     std::vector<std::pair<std::string, Token::Kind>> arrayTypes = reader.getNamedArrayTypes();
     ASSERT_FALSE( arrayTypes.empty() );
 
-    auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind ) {
+    auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind )
+    {
         auto x =
             std::find_if( values.begin(), values.end(), [&keyword]( const auto& arg ) { return arg.first == keyword; } );
         return x != values.end() && x->second == kind;
     };
 
-    ASSERT_TRUE( hasValue( arrayTypes, "composite.codeValues", Token::Kind::INT ) );
+    ASSERT_TRUE( hasValue( arrayTypes, "composite" + roff::Parser::postFixCodeValues(), Token::Kind::INT ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.floatData", Token::Kind::FLOAT ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.doubleData", Token::Kind::DOUBLE ) );
     ASSERT_TRUE( hasValue( arrayTypes, "parameter.intData", Token::Kind::INT ) );
 
-    std::vector<int> codeValues = reader.getIntArray( "composite.codeValues" );
+    std::vector<int> codeValues = reader.getIntArray( "composite" + roff::Parser::postFixCodeValues() );
     ASSERT_EQ( 6u, codeValues.size() );
     for ( int i = 0; i < 6; i++ )
     {
@@ -241,29 +247,30 @@ TEST( ReaderTests, testParseGridFiles )
         std::vector<std::pair<std::string, Token::Kind>> arrayTypes = reader.getNamedArrayTypes();
         ASSERT_FALSE( arrayTypes.empty() );
 
-        auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind ) {
-            auto x = std::find_if( values.begin(), values.end(), [&keyword]( const auto& arg ) {
-                return arg.first == keyword;
-            } );
+        auto hasValue = []( auto values, const std::string& keyword, Token::Kind kind )
+        {
+            auto x = std::find_if( values.begin(),
+                                   values.end(),
+                                   [&keyword]( const auto& arg ) { return arg.first == keyword; } );
             return x != values.end() && x->second == kind;
         };
 
-        ASSERT_TRUE( hasValue( arrayTypes, "zvalues.data", Token::Kind::FLOAT ) );
+        ASSERT_TRUE( hasValue( arrayTypes, "zvalues" + roff::Parser::postFixData(), Token::Kind::FLOAT ) );
         ASSERT_TRUE( hasValue( arrayTypes, "zvalues.splitEnz", Token::Kind::BYTE ) );
         ASSERT_TRUE( hasValue( arrayTypes, "PORO", Token::Kind::FLOAT ) );
 
-        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM.codeNames", Token::Kind::CHAR ) );
-        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM.codeValues", Token::Kind::INT ) );
+        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM" + roff::Parser::postFixCodeNames(), Token::Kind::CHAR ) );
+        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM" + roff::Parser::postFixCodeValues(), Token::Kind::INT ) );
 
-        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM.codeNames", Token::Kind::CHAR ) );
-        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM.codeValues", Token::Kind::INT ) );
+        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM" + roff::Parser::postFixCodeNames(), Token::Kind::CHAR ) );
+        ASSERT_TRUE( hasValue( arrayTypes, "EQLNUM" + roff::Parser::postFixCodeValues(), Token::Kind::INT ) );
 
-        std::vector<int> codeValues = reader.getIntArray( "EQLNUM.codeValues" );
+        std::vector<int> codeValues = reader.getIntArray( "EQLNUM" + roff::Parser::postFixCodeValues() );
         ASSERT_EQ( 2u, codeValues.size() );
         ASSERT_EQ( 1, codeValues[0] );
         ASSERT_EQ( 2, codeValues[1] );
 
-        std::vector<std::string> codeNames = reader.getStringArray( "EQLNUM.codeNames" );
+        std::vector<std::string> codeNames = reader.getStringArray( "EQLNUM" + roff::Parser::postFixCodeNames() );
         ASSERT_EQ( 2u, codeNames.size() );
         ASSERT_EQ( "", codeNames[0] );
         ASSERT_EQ( "", codeNames[1] );


### PR DESCRIPTION
Up to three types of data can be related. This is organized by the parameter name and a string .data/.codeNames/.codeValues. This will ensure that asking for these parameters from external code is robust.